### PR TITLE
Update CI Runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     name: cargo build and test
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-22.04-github-hosted-32core]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
# What ❔

This PR gives CI `ubuntu-22.04-github-hosted-32core` runner

## Why ❔

The tests in this repo are very heavy.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
