### PR TITLE
fix(cargo): Fixing a version of arrayvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ smallvec = { version = "*", features = [
     "const_new",
     "serde",
 ] }
-arrayvec = "*"
+arrayvec = "0.7"
 zkevm_opcode_defs = {git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.3.2"}
 boojum = {git = "https://github.com/matter-labs/era-boojum.git", branch = "main"}
 # boojum = { path = "../boojum" }


### PR DESCRIPTION
# What ❔

* Fixing a version of arrayvec to 0.7


## Why ❔

* Before it was a star - which caused it in some cases to use arrayvec 0.4 (if other crate depended on it) - which caused compilation errors (as 0.4 had only one template parameter)
