### PR TITLE
Grow heap bounds on return from near call frame

### DIFF
--- a/src/main_vm/opcodes/call_ret_impl/ret.rs
+++ b/src/main_vm/opcodes/call_ret_impl/ret.rs
@@ -294,6 +294,18 @@ where
         ergs_left_after_growth.add_no_overflow(cs, new_callstack_entry.ergs_remaining);
 
     new_callstack_entry.ergs_remaining = new_ergs_left;
+    new_callstack_entry.heap_upper_bound = Selectable::conditionally_select(
+        cs,
+        is_local_frame,
+        &heap_bound,
+        &new_callstack_entry.heap_upper_bound,
+    );
+    new_callstack_entry.aux_heap_upper_bound = Selectable::conditionally_select(
+        cs,
+        is_local_frame,
+        &aux_heap_bound,
+        &new_callstack_entry.aux_heap_upper_bound,
+    );
 
     // resolve merging of the queues
 


### PR DESCRIPTION
# What ❔

Grows heap bounds on return from near call frame.

## Why ❔

This wasn't being done properly before and could cause issues with memory management.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
