### PR TITLE
fix: remove unnecessary mut ref aliasing

### DIFF
--- a/src/recursion/compression/mod.rs
+++ b/src/recursion/compression/mod.rs
@@ -72,10 +72,6 @@ pub fn proof_compression_function<
         ..
     } = config;
 
-    // use this and deal with borrow checker
-
-    let r = cs as *mut CS;
-
     assert_eq!(
         verification_key.fixed_parameters.parameters,
         verifier_builder.geometry()
@@ -84,8 +80,6 @@ pub fn proof_compression_function<
     let fixed_parameters = verification_key.fixed_parameters.clone();
 
     let verifier = verifier_builder.create_recursive_verifier(cs);
-
-    let cs = unsafe { &mut *r };
 
     let vk = AllocatedVerificationKey::allocate_constant(cs, verification_key);
 

--- a/src/recursion/interblock/mod.rs
+++ b/src/recursion/interblock/mod.rs
@@ -91,10 +91,6 @@ pub fn interblock_recursion_function<
         ..
     } = config;
 
-    // use this and deal with borrow checker
-
-    let r = cs as *mut CS;
-
     assert_eq!(
         verification_key.fixed_parameters.parameters,
         verifier_builder.geometry()
@@ -103,8 +99,6 @@ pub fn interblock_recursion_function<
     let fixed_parameters = verification_key.fixed_parameters.clone();
 
     let verifier = verifier_builder.create_recursive_verifier(cs);
-
-    let cs = unsafe { &mut *r };
 
     let mut validity_flags = Vec::with_capacity(capacity);
     let mut inputs = Vec::with_capacity(capacity);

--- a/src/recursion/leaf_layer/mod.rs
+++ b/src/recursion/leaf_layer/mod.rs
@@ -135,17 +135,9 @@ where
         ..
     } = config;
 
-    // use this and deal with borrow checker
-
-    let r = cs as *mut CS;
-
     assert_eq!(vk_fixed_parameters.parameters, verifier_builder.geometry());
 
     let verifier = verifier_builder.create_recursive_verifier(cs);
-
-    drop(cs);
-
-    let cs = unsafe { &mut *r };
 
     for _ in 0..capacity {
         let proof_witness = proof_witnesses.pop_front();

--- a/src/recursion/node_layer/mod.rs
+++ b/src/recursion/node_layer/mod.rs
@@ -163,17 +163,9 @@ where
 
     let mut proof_witnesses = proof_witnesses;
 
-    // use this and deal with borrow checker
-
-    let r = cs as *mut CS;
-
     assert_eq!(vk_fixed_parameters.parameters, verifier_builder.geometry());
 
     let verifier = verifier_builder.create_recursive_verifier(cs);
-
-    drop(cs);
-
-    let cs = unsafe { &mut *r };
 
     let subqueues = split_queue_state_into_n(cs, queue_state, node_layer_capacity, split_points);
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -848,18 +848,12 @@ pub fn scheduler_function<
     let mut proof_witnesses = witness.proof_witnesses;
 
     // create verifier
-    let r = cs as *mut CS;
-
     assert_eq!(
         config.vk_fixed_parameters.parameters,
         verifier_builder.geometry()
     );
 
     let verifier = verifier_builder.create_recursive_verifier(cs);
-
-    drop(cs);
-
-    let cs = unsafe { &mut *r };
 
     for (_idx, (circuit_type, state)) in SEQUENCE_OF_CIRCUIT_TYPES
         .iter()


### PR DESCRIPTION
# What ❔

Removes unnecessary casts of the CS mutable reference to a pointer stored in a variable and then re-initialize. I'm assuming this was necessary in a past version, but I can't think of a reason it's needed right now.

## Why ❔

Remove unnecessary unsafe code and potentially avoid misuse in the future.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
