### PR TITLE
Mirror 1c47420

### DIFF
--- a/src/demux_log_queue/input.rs
+++ b/src/demux_log_queue/input.rs
@@ -108,6 +108,10 @@ impl<F: SmallField> LogDemuxerOutputData<F> {
                 DemuxOutput::Secp256r1Verify,
                 &self.output_queue_states[DemuxOutput::Secp256r1Verify as usize],
             ),
+            (
+                DemuxOutput::TransientStorage,
+                &self.output_queue_states[DemuxOutput::TransientStorage as usize],
+            ),
         ];
         assert_eq!(tuples.len(), NUM_DEMUX_OUTPUTS);
 

--- a/src/main_vm/opcodes/log.rs
+++ b/src/main_vm/opcodes/log.rs
@@ -711,7 +711,7 @@ pub(crate) fn apply_log<
         unsafe { old_forward_queue_length.increment_unchecked(cs) };
     let new_forward_queue_length = UInt32::conditionally_select(
         cs,
-        should_apply,
+        should_apply_io,
         &new_forward_queue_length_candidate,
         &old_forward_queue_length,
     );

--- a/src/recursion/leaf_layer/input.rs
+++ b/src/recursion/leaf_layer/input.rs
@@ -40,6 +40,27 @@ impl<F: SmallField> CSPlaceholder<F> for RecursionLeafParameters<F> {
     }
 }
 
+impl<F: SmallField> RecursionLeafParameters<F> {
+    pub fn allocated_constant<CS: ConstraintSystem<F>>(
+        cs: &mut CS,
+        value: <Self as CSAllocatable<F>>::Witness,
+    ) -> Self {
+        let circuit_type = Num::allocated_constant(cs, value.circuit_type);
+        let basic_circuit_vk_commitment = value
+            .basic_circuit_vk_commitment
+            .map(|el| Num::allocated_constant(cs, el));
+        let leaf_layer_vk_commitment = value
+            .leaf_layer_vk_commitment
+            .map(|el| Num::allocated_constant(cs, el));
+
+        Self {
+            circuit_type,
+            basic_circuit_vk_commitment,
+            leaf_layer_vk_commitment,
+        }
+    }
+}
+
 #[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]

--- a/src/recursion/recursion_tip/mod.rs
+++ b/src/recursion/recursion_tip/mod.rs
@@ -8,7 +8,6 @@ use boojum::gadgets::recursion::allocated_vk::AllocatedVerificationKey;
 use boojum::gadgets::recursion::recursive_transcript::RecursiveTranscript;
 use boojum::gadgets::recursion::recursive_tree_hasher::RecursiveTreeHasher;
 
-use crate::boojum::cs::gates::PublicInputGate;
 use crate::fsm_input_output::circuit_inputs::INPUT_OUTPUT_COMMITMENT_LENGTH;
 use boojum::algebraic_props::round_function::AlgebraicRoundFunction;
 use boojum::cs::traits::cs::ConstraintSystem;
@@ -161,10 +160,13 @@ where
 
     let input_commitment: [_; INPUT_OUTPUT_COMMITMENT_LENGTH] =
         commit_variable_length_encodable_item(cs, &input, round_function);
-    for el in input_commitment.iter() {
-        let gate = PublicInputGate::new(el.get_variable());
-        gate.add_to_cs(cs);
-    }
+    // NOTE: we usually put inputs as fixed places for all recursive circuits, even though for this type
+    // we do not have to do it strictly speaking
+
+    // for el in input_commitment.iter() {
+    //     let gate = PublicInputGate::new(el.get_variable());
+    //     gate.add_to_cs(cs);
+    // }
 
     input_commitment
 }

--- a/src/scheduler/input.rs
+++ b/src/scheduler/input.rs
@@ -1,6 +1,5 @@
 use super::*;
 use boojum::cs::implementations::proof::Proof;
-use boojum::cs::implementations::verifier::VerificationKey;
 
 use boojum::field::SmallField;
 
@@ -83,10 +82,6 @@ pub struct SchedulerCircuitInstanceWitness<
     // proofs for every individual circuit type's aggregation subtree
     #[derivative(Debug = "ignore")]
     pub proof_witnesses: VecDeque<Proof<F, H::NonCircuitSimulator, EXT>>,
-    #[derivative(Debug = "ignore")]
-    pub node_layer_vk_witness: VerificationKey<F, H::NonCircuitSimulator>,
-    #[derivative(Debug = "ignore")]
-    pub leaf_layer_parameters: [RecursionLeafParametersWitness<F>; NUM_CIRCUIT_TYPES_TO_SCHEDULE],
 }
 
 impl<F: SmallField, H: RecursiveTreeHasher<F, Num<F>>, EXT: FieldExtension<2, BaseField = F>>
@@ -136,10 +131,6 @@ impl<F: SmallField, H: RecursiveTreeHasher<F, Num<F>>, EXT: FieldExtension<2, Ba
             eip4844_witnesses: std::array::from_fn(|_| None),
 
             proof_witnesses: VecDeque::new(),
-            node_layer_vk_witness: VerificationKey::default(),
-            leaf_layer_parameters: std::array::from_fn(|_| {
-                RecursionLeafParameters::placeholder_witness()
-            }),
         }
     }
 }


### PR DESCRIPTION
# What ❔

Mirror 1c47420.

* Changed a way how we compute block hash (it no longer takes recursion and leafs hashes as parameters)
* Added recursion_tip to scheduler config
* And a bunch of small fixes for the transient storage and log opcode