### PR TITLE
if there is no enough ergs for decommit, they remain the same

### DIFF
--- a/src/main_vm/opcodes/call_ret_impl/far_call.rs
+++ b/src/main_vm/opcodes/call_ret_impl/far_call.rs
@@ -1671,8 +1671,12 @@ where
     let should_decommit = Boolean::multi_and(cs, &[*should_decommit, have_enough_ergs_to_decommit]);
 
     // if we do not decommit then we will eventually map into 0 page for 0 extra ergs
-    let ergs_remaining_after_decommit =
-        ergs_after_decommit_may_be.mask_negated(cs, not_enough_ergs_to_decommit);
+    let ergs_remaining_after_decommit = UInt32::conditionally_select(
+        cs, 
+        have_enough_ergs_to_decommit, 
+        &ergs_after_decommit_may_be, 
+        &ergs_remaining
+    );
 
     if crate::config::CIRCUIT_VERSOBE {
         if should_decommit.witness_hook(&*cs)().unwrap() {


### PR DESCRIPTION
# What ❔

Fixed remaining ergs computation in decommitments

## Why ❔

It should be the same as in out-of-circuit VM