### PR TITLE
Derive WitnessVarLengthEncodable for witnesses used in BWG

### DIFF
--- a/src/base_structures/decommit_query/mod.rs
+++ b/src/base_structures/decommit_query/mod.rs
@@ -11,13 +11,21 @@ use boojum::gadgets::traits::allocatable::CSPlaceholder;
 use boojum::gadgets::traits::allocatable::{CSAllocatable, CSAllocatableExt};
 use boojum::gadgets::traits::castable::WitnessCastable;
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::encodable::{CircuitEncodable, CircuitEncodableExt};
 use boojum::gadgets::traits::selectable::Selectable;
 use boojum::gadgets::traits::witnessable::WitnessHookable;
 use boojum::gadgets::u32::UInt32;
 use boojum::{field::SmallField, gadgets::u256::UInt256};
 
-#[derive(Derivative, CSAllocatable, CSSelectable, WitnessHookable, CSVarLengthEncodable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    WitnessHookable,
+    CSVarLengthEncodable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 pub struct DecommitQuery<F: SmallField> {
     pub code_hash: UInt256<F>,

--- a/src/base_structures/log_query/mod.rs
+++ b/src/base_structures/log_query/mod.rs
@@ -9,7 +9,9 @@ use boojum::gadgets::traits::allocatable::CSPlaceholder;
 use boojum::gadgets::traits::allocatable::{CSAllocatable, CSAllocatableExt};
 use boojum::gadgets::traits::castable::WitnessCastable;
 use boojum::gadgets::traits::encodable::CircuitEncodableExt;
-use boojum::gadgets::traits::encodable::{CircuitEncodable, CircuitVarLengthEncodable};
+use boojum::gadgets::traits::encodable::{
+    CircuitEncodable, CircuitVarLengthEncodable, WitnessVarLengthEncodable,
+};
 use boojum::gadgets::traits::selectable::Selectable;
 use boojum::gadgets::traits::witnessable::WitnessHookable;
 use boojum::gadgets::u160::{recompose_address_from_u32x5, UInt160};
@@ -18,7 +20,14 @@ use boojum::gadgets::u32::UInt32;
 use boojum::gadgets::u8::UInt8;
 use cs_derive::*;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, WitnessHookable, CSVarLengthEncodable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    WitnessHookable,
+    CSVarLengthEncodable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug, Hash)]
 pub struct LogQuery<F: SmallField> {
     pub address: UInt160<F>,

--- a/src/base_structures/precompile_input_outputs/mod.rs
+++ b/src/base_structures/precompile_input_outputs/mod.rs
@@ -13,11 +13,19 @@ use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::CSPlaceholder;
 use boojum::gadgets::traits::auxiliary::PrettyComparison;
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::selectable::Selectable;
 use boojum::gadgets::traits::witnessable::WitnessHookable;
 use cs_derive::*;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct PrecompileFunctionInputData<F: SmallField> {
@@ -36,7 +44,14 @@ impl<F: SmallField> CSPlaceholder<F> for PrecompileFunctionInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct PrecompileFunctionOutputData<F: SmallField> {

--- a/src/base_structures/register/mod.rs
+++ b/src/base_structures/register/mod.rs
@@ -11,12 +11,20 @@ use boojum::cs::traits::cs::DstBuffer;
 use boojum::cs::Variable;
 use boojum::gadgets::traits::allocatable::{CSAllocatable, CSAllocatableExt};
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::selectable::Selectable;
 use boojum::gadgets::traits::witnessable::WitnessHookable;
 
 use cs_derive::*;
 
-#[derive(Derivative, CSSelectable, CSAllocatable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSSelectable,
+    CSAllocatable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug, Hash)]
 pub struct VMRegister<F: SmallField> {
     pub is_pointer: Boolean<F>,

--- a/src/base_structures/vm_state/callstack.rs
+++ b/src/base_structures/vm_state/callstack.rs
@@ -1,7 +1,14 @@
 use super::*;
 use boojum::serde_utils::BigArraySerde;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[CSSelectableBound(
     "where [(); <ExecutionContextRecord::<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:"
@@ -40,7 +47,9 @@ use crate::base_structures::vm_state::saved_context::ExecutionContextRecord;
 
 // execution context that keeps all explicit data about the current execution frame,
 // and avoid recomputing of quantities that also do not change between calls
-#[derive(Derivative, CSAllocatable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative, CSAllocatable, CSVarLengthEncodable, WitnessHookable, WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 pub struct FullExecutionContext<F: SmallField> {
     pub saved_context: ExecutionContextRecord<F>,

--- a/src/base_structures/vm_state/mod.rs
+++ b/src/base_structures/vm_state/mod.rs
@@ -9,6 +9,7 @@ use boojum::gadgets::num::Num;
 use boojum::gadgets::traits::allocatable::*;
 use boojum::gadgets::traits::auxiliary::PrettyComparison;
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::selectable::*;
 use boojum::gadgets::traits::witnessable::WitnessHookable;
 use boojum::gadgets::u16::UInt16;
@@ -29,7 +30,9 @@ pub const QUEUE_STATE_WIDTH: usize = 4;
 
 use zkevm_opcode_defs::REGISTERS_COUNT;
 
-#[derive(Derivative, CSAllocatable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative, CSAllocatable, CSVarLengthEncodable, WitnessHookable, WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 pub struct ArithmeticFlagsPort<F: SmallField> {
     pub overflow_or_less_than: Boolean<F>,
@@ -83,7 +86,14 @@ impl<F: SmallField> ArithmeticFlagsPort<F> {
     }
 }
 
-#[derive(Derivative, CSSelectable, CSAllocatable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSSelectable,
+    CSAllocatable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[CSSelectableBound(
     "where [(); <ExecutionContextRecord::<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:"
@@ -153,7 +163,14 @@ impl<F: SmallField> CSPlaceholder<F> for VmLocalState<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 pub struct GlobalContext<F: SmallField> {
     pub zkporter_is_available: Boolean<F>,

--- a/src/base_structures/vm_state/saved_context.rs
+++ b/src/base_structures/vm_state/saved_context.rs
@@ -4,6 +4,7 @@ use boojum::cs::Variable;
 use boojum::gadgets::traits::allocatable::CSAllocatableExt;
 use boojum::gadgets::traits::castable::WitnessCastable;
 use boojum::gadgets::traits::encodable::CircuitEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::selectable::parallel_select_variables;
 use cs_derive::*;
 use ethereum_types::Address;
@@ -31,7 +32,9 @@ use super::*;
 // - per-context computed rollback segment length
 // - per-context rollback_head
 
-#[derive(Derivative, CSAllocatable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative, CSAllocatable, CSVarLengthEncodable, WitnessHookable, WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 pub struct ExecutionContextRecord<F: SmallField> {
     pub this: UInt160<F>, // unfortunately delegatecall mangles this field - it can not be restored from callee's caller

--- a/src/code_unpacker_sha256/input.rs
+++ b/src/code_unpacker_sha256/input.rs
@@ -7,8 +7,8 @@ use boojum::gadgets::{
     boolean::Boolean,
     queue::*,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
     u16::UInt16,
     u256::UInt256,
@@ -18,7 +18,14 @@ use boojum::serde_utils::BigArraySerde;
 use cs_derive::*;
 use derivative::*;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 pub struct CodeDecommittmentFSM<F: SmallField> {
     pub sha256_inner_state: [UInt32<F>; 8], // 8 uint32 words of internal sha256 state
@@ -53,7 +60,14 @@ impl<F: SmallField> CSPlaceholder<F> for CodeDecommittmentFSM<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct CodeDecommitterFSMInputOutput<F: SmallField> {
@@ -73,7 +87,14 @@ impl<F: SmallField> CSPlaceholder<F> for CodeDecommitterFSMInputOutput<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 pub struct CodeDecommitterInputData<F: SmallField> {
     pub memory_queue_initial_state: QueueState<F, FULL_SPONGE_QUEUE_STATE_WIDTH>,
@@ -92,7 +113,14 @@ impl<F: SmallField> CSPlaceholder<F> for CodeDecommitterInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct CodeDecommitterOutputData<F: SmallField> {

--- a/src/demux_log_queue/input.rs
+++ b/src/demux_log_queue/input.rs
@@ -12,8 +12,8 @@ use boojum::gadgets::{
     boolean::Boolean,
     queue::*,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
 };
 use boojum::serde_utils::BigArraySerde;
@@ -22,7 +22,14 @@ use derivative::*;
 
 use super::NUM_DEMUX_OUTPUTS;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct LogDemuxerFSMInputOutput<F: SmallField> {
@@ -40,7 +47,14 @@ impl<F: SmallField> CSPlaceholder<F> for LogDemuxerFSMInputOutput<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct LogDemuxerInputData<F: SmallField> {
@@ -55,7 +69,14 @@ impl<F: SmallField> CSPlaceholder<F> for LogDemuxerInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct LogDemuxerOutputData<F: SmallField> {

--- a/src/ecrecover/input.rs
+++ b/src/ecrecover/input.rs
@@ -7,11 +7,18 @@ use boojum::cs::Variable;
 use boojum::gadgets::queue::*;
 use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::CSPlaceholder;
-use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
-
 use boojum::gadgets::traits::auxiliary::PrettyComparison;
+use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct EcrecoverCircuitFSMInputOutput<F: SmallField> {

--- a/src/eip_4844/input.rs
+++ b/src/eip_4844/input.rs
@@ -11,7 +11,8 @@ use boojum::gadgets::u8::UInt8;
 use boojum::gadgets::{
     boolean::Boolean,
     traits::{
-        encodable::CircuitVarLengthEncodable, selectable::Selectable, witnessable::WitnessHookable,
+        encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
 };
 use boojum::serde_utils::BigArraySerde;
@@ -27,7 +28,14 @@ pub struct BlobChunk<F: SmallField> {
     pub inner: [UInt8<F>; BLOB_CHUNK_SIZE],
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitVarLengthEncodable,
+    WitnessHookable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct EIP4844OutputData<F: SmallField> {

--- a/src/fsm_input_output/circuit_inputs/main_vm.rs
+++ b/src/fsm_input_output/circuit_inputs/main_vm.rs
@@ -4,7 +4,14 @@ use crate::base_structures::vm_state::*;
 use boojum::gadgets::queue::*;
 use boojum::serde_utils::BigArraySerde;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Debug)]
 pub struct VmInputData<F: SmallField> {
     pub rollback_queue_tail_for_block: [Num<F>; QUEUE_STATE_WIDTH],
@@ -27,7 +34,14 @@ impl<F: SmallField> CSPlaceholder<F> for VmInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct VmOutputData<F: SmallField> {

--- a/src/fsm_input_output/mod.rs
+++ b/src/fsm_input_output/mod.rs
@@ -13,6 +13,7 @@ use boojum::gadgets::num::Num;
 use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::CSPlaceholder;
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::round_function::CircuitRoundFunction;
 use boojum::gadgets::traits::selectable::Selectable;
 use boojum::gadgets::traits::witnessable::WitnessHookable;
@@ -33,9 +34,24 @@ where
 #[derivative(Clone, Debug)]
 pub struct ClosedFormInput<
     F: SmallField,
-    T: Clone + std::fmt::Debug + CSAllocatable<F> + CircuitVarLengthEncodable<F> + WitnessHookable<F>,
-    IN: Clone + std::fmt::Debug + CSAllocatable<F> + CircuitVarLengthEncodable<F> + WitnessHookable<F>,
-    OUT: Clone + std::fmt::Debug + CSAllocatable<F> + CircuitVarLengthEncodable<F> + WitnessHookable<F>,
+    T: Clone
+        + std::fmt::Debug
+        + CSAllocatable<F>
+        + CircuitVarLengthEncodable<F>
+        + WitnessVarLengthEncodable<F>
+        + WitnessHookable<F>,
+    IN: Clone
+        + std::fmt::Debug
+        + CSAllocatable<F>
+        + CircuitVarLengthEncodable<F>
+        + WitnessVarLengthEncodable<F>
+        + WitnessHookable<F>,
+    OUT: Clone
+        + std::fmt::Debug
+        + CSAllocatable<F>
+        + CircuitVarLengthEncodable<F>
+        + WitnessVarLengthEncodable<F>
+        + WitnessHookable<F>,
 > where
     <T as CSAllocatable<F>>::Witness: serde::Serialize + serde::de::DeserializeOwned + Eq,
     <IN as CSAllocatable<F>>::Witness: serde::Serialize + serde::de::DeserializeOwned + Eq,
@@ -55,16 +71,19 @@ impl<
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
         IN: Clone
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
         OUT: Clone
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
     > ClosedFormInput<F, T, IN, OUT>
 where
@@ -143,16 +162,19 @@ impl<
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
         IN: Clone
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
         OUT: Clone
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
     > std::default::Default for ClosedFormInputWitness<F, T, IN, OUT>
 where
@@ -165,7 +187,14 @@ where
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Debug)]
 pub struct ClosedFormInputCompactForm<F: SmallField> {
     pub start_flag: Boolean<F>,
@@ -255,16 +284,19 @@ impl<F: SmallField> ClosedFormInputCompactForm<F> {
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
         IN: Clone
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
         OUT: Clone
             + std::fmt::Debug
             + CSAllocatable<F>
             + CircuitVarLengthEncodable<F>
+            + WitnessVarLengthEncodable<F>
             + WitnessHookable<F>,
         R: CircuitRoundFunction<F, 8, 12, 4>,
     >(

--- a/src/keccak256_round_function/buffer/mod.rs
+++ b/src/keccak256_round_function/buffer/mod.rs
@@ -2,7 +2,14 @@ use super::*;
 use crate::boojum::gadgets::traits::auxiliary::PrettyComparison;
 use crate::boojum::serde_utils::BigArraySerde;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct ByteBuffer<F: SmallField, const BUFFER_SIZE: usize> {

--- a/src/keccak256_round_function/input.rs
+++ b/src/keccak256_round_function/input.rs
@@ -10,6 +10,7 @@ use boojum::gadgets::queue::*;
 use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::CSPlaceholder;
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 
 use boojum::cs::traits::cs::ConstraintSystem;
 use boojum::field::SmallField;
@@ -23,7 +24,14 @@ use boojum::serde_utils::BigArraySerde;
 pub const MEMORY_QUERIES_PER_CYCLE: usize = 6;
 pub const KECCAK_PRECOMPILE_BUFFER_SIZE: usize = MEMORY_QUERIES_PER_CYCLE * 32;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct Keccak256RoundFunctionFSM<F: SmallField> {
@@ -57,7 +65,14 @@ impl<F: SmallField> CSPlaceholder<F> for Keccak256RoundFunctionFSM<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct Keccak256RoundFunctionFSMInputOutput<F: SmallField> {

--- a/src/keccak256_round_function/mod.rs
+++ b/src/keccak256_round_function/mod.rs
@@ -32,6 +32,7 @@ use boojum::gadgets::queue::QueueState;
 use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::{CSAllocatableExt, CSPlaceholder};
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::round_function::CircuitRoundFunction;
 use boojum::gadgets::u160::UInt160;
 use boojum::gadgets::u8::UInt8;
@@ -42,7 +43,14 @@ pub mod buffer;
 pub mod input;
 use self::input::*;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 // #[DerivePrettyComparison("true")]
 pub struct Keccak256PrecompileCallParams<F: SmallField> {

--- a/src/linear_hasher/input.rs
+++ b/src/linear_hasher/input.rs
@@ -12,15 +12,22 @@ use boojum::gadgets::{
     boolean::Boolean,
     queue::*,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
 };
 use boojum::serde_utils::BigArraySerde;
 use cs_derive::*;
 use derivative::*;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct LinearHasherInputData<F: SmallField> {
@@ -35,7 +42,14 @@ impl<F: SmallField> CSPlaceholder<F> for LinearHasherInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct LinearHasherOutputData<F: SmallField> {

--- a/src/log_sorter/input.rs
+++ b/src/log_sorter/input.rs
@@ -12,8 +12,8 @@ use boojum::gadgets::{
     num::Num,
     queue::*,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
 };
 use boojum::serde_utils::BigArraySerde;
@@ -22,7 +22,14 @@ use derivative::*;
 
 use crate::DEFAULT_NUM_PERMUTATION_ARGUMENT_REPETITIONS;
 
-#[derive(Derivative, CSAllocatable, CSVarLengthEncodable, CSSelectable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSVarLengthEncodable,
+    CSSelectable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct EventsDeduplicatorFSMInputOutput<F: SmallField> {
@@ -51,7 +58,14 @@ impl<F: SmallField> CSPlaceholder<F> for EventsDeduplicatorFSMInputOutput<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct EventsDeduplicatorInputData<F: SmallField> {
@@ -68,7 +82,14 @@ impl<F: SmallField> CSPlaceholder<F> for EventsDeduplicatorInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct EventsDeduplicatorOutputData<F: SmallField> {

--- a/src/ram_permutation/input.rs
+++ b/src/ram_permutation/input.rs
@@ -12,8 +12,8 @@ use boojum::gadgets::{
     queue::full_state_queue::*,
     queue::*,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
     u256::UInt256,
     u32::UInt32,
@@ -22,7 +22,14 @@ use boojum::serde_utils::BigArraySerde;
 use cs_derive::*;
 use derivative::*;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Debug)]
 pub struct RamPermutationInputData<F: SmallField> {
     pub unsorted_queue_initial_state: QueueState<F, FULL_SPONGE_QUEUE_STATE_WIDTH>,
@@ -46,7 +53,14 @@ impl<F: SmallField> CSPlaceholder<F> for RamPermutationInputData<F> {
 pub const RAM_SORTING_KEY_LENGTH: usize = 3;
 pub const RAM_FULL_KEY_LENGTH: usize = 2;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct RamPermutationFSMInputOutput<F: SmallField> {

--- a/src/recursion/leaf_layer/input.rs
+++ b/src/recursion/leaf_layer/input.rs
@@ -11,8 +11,8 @@ use boojum::gadgets::traits::auxiliary::PrettyComparison;
 use boojum::gadgets::{
     boolean::Boolean,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
 };
 use cs_derive::*;
@@ -20,7 +20,14 @@ use cs_derive::*;
 use boojum::field::FieldExtension;
 use boojum::serde_utils::BigArraySerde;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct RecursionLeafParameters<F: SmallField> {

--- a/src/secp256r1_verify/input.rs
+++ b/src/secp256r1_verify/input.rs
@@ -8,10 +8,18 @@ use boojum::gadgets::queue::*;
 use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::CSPlaceholder;
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 
 use boojum::gadgets::traits::auxiliary::PrettyComparison;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct Secp256r1VerifyCircuitFSMInputOutput<F: SmallField> {

--- a/src/sha256_round_function/input.rs
+++ b/src/sha256_round_function/input.rs
@@ -9,6 +9,7 @@ use boojum::gadgets::queue::*;
 use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::CSPlaceholder;
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 
 use boojum::cs::traits::cs::ConstraintSystem;
 use boojum::field::SmallField;
@@ -18,7 +19,14 @@ use boojum::gadgets::traits::selectable::Selectable;
 use boojum::gadgets::traits::witnessable::WitnessHookable;
 use boojum::serde_utils::BigArraySerde;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct Sha256RoundFunctionFSM<F: SmallField> {
@@ -47,7 +55,14 @@ impl<F: SmallField> CSPlaceholder<F> for Sha256RoundFunctionFSM<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct Sha256RoundFunctionFSMInputOutput<F: SmallField> {

--- a/src/sha256_round_function/mod.rs
+++ b/src/sha256_round_function/mod.rs
@@ -30,6 +30,7 @@ use boojum::gadgets::sha256::{self};
 use boojum::gadgets::traits::allocatable::CSAllocatable;
 use boojum::gadgets::traits::allocatable::{CSAllocatableExt, CSPlaceholder};
 use boojum::gadgets::traits::encodable::CircuitVarLengthEncodable;
+use boojum::gadgets::traits::encodable::WitnessVarLengthEncodable;
 use boojum::gadgets::traits::round_function::CircuitRoundFunction;
 use boojum::gadgets::u160::UInt160;
 use boojum::gadgets::u8::UInt8;
@@ -38,7 +39,14 @@ use std::sync::{Arc, RwLock};
 pub mod input;
 use self::input::*;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 // #[DerivePrettyComparison("true")]
 pub struct Sha256PrecompileCallParams<F: SmallField> {

--- a/src/sort_decommittment_requests/input.rs
+++ b/src/sort_decommittment_requests/input.rs
@@ -9,8 +9,8 @@ use boojum::gadgets::u32::UInt32;
 use boojum::gadgets::{
     boolean::Boolean,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
 };
 use boojum::serde_utils::BigArraySerde;
@@ -18,7 +18,14 @@ use cs_derive::*;
 
 pub const PACKED_KEY_LENGTH: usize = 8 + 1;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct CodeDecommittmentsDeduplicatorFSMInputOutput<F: SmallField> {
@@ -54,7 +61,14 @@ impl<F: SmallField> CSPlaceholder<F> for CodeDecommittmentsDeduplicatorFSMInputO
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct CodeDecommittmentsDeduplicatorInputData<F: SmallField> {
@@ -73,7 +87,14 @@ impl<F: SmallField> CSPlaceholder<F> for CodeDecommittmentsDeduplicatorInputData
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct CodeDecommittmentsDeduplicatorOutputData<F: SmallField> {

--- a/src/storage_application/input.rs
+++ b/src/storage_application/input.rs
@@ -12,8 +12,8 @@ use boojum::gadgets::{
     boolean::Boolean,
     queue::*,
     traits::{
-        allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
-        witnessable::WitnessHookable,
+        allocatable::*, encodable::CircuitVarLengthEncodable, encodable::WitnessVarLengthEncodable,
+        selectable::Selectable, witnessable::WitnessHookable,
     },
 };
 use boojum::serde_utils::BigArraySerde;
@@ -23,7 +23,14 @@ use std::collections::VecDeque;
 
 pub const STORAGE_DEPTH: usize = 256;
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct StorageApplicationFSMInputOutput<F: SmallField> {
@@ -50,7 +57,14 @@ impl<F: SmallField> CSPlaceholder<F> for StorageApplicationFSMInputOutput<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct StorageApplicationInputData<F: SmallField> {
@@ -71,7 +85,14 @@ impl<F: SmallField> CSPlaceholder<F> for StorageApplicationInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct StorageApplicationOutputData<F: SmallField> {

--- a/src/storage_validity_by_grand_product/input.rs
+++ b/src/storage_validity_by_grand_product/input.rs
@@ -12,7 +12,8 @@ use boojum::{
         num::*,
         queue::*,
         traits::{
-            allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
+            allocatable::*, encodable::CircuitVarLengthEncodable,
+            encodable::WitnessVarLengthEncodable, selectable::Selectable,
             witnessable::WitnessHookable,
         },
         u160::*,
@@ -31,7 +32,14 @@ use super::TimestampedStorageLogRecord;
 
 // FSM
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct StorageDeduplicatorFSMInputOutput<F: SmallField> {
@@ -79,7 +87,14 @@ impl<F: SmallField> CSPlaceholder<F> for StorageDeduplicatorFSMInputOutput<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Debug)]
 pub struct StorageDeduplicatorInputData<F: SmallField> {
     pub shard_id_to_process: UInt8<F>,
@@ -97,7 +112,14 @@ impl<F: SmallField> CSPlaceholder<F> for StorageDeduplicatorInputData<F> {
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct StorageDeduplicatorOutputData<F: SmallField> {

--- a/src/transient_storage_validity_by_grand_product/input.rs
+++ b/src/transient_storage_validity_by_grand_product/input.rs
@@ -12,7 +12,8 @@ use boojum::{
         num::*,
         queue::*,
         traits::{
-            allocatable::*, encodable::CircuitVarLengthEncodable, selectable::Selectable,
+            allocatable::*, encodable::CircuitVarLengthEncodable,
+            encodable::WitnessVarLengthEncodable, selectable::Selectable,
             witnessable::WitnessHookable,
         },
         u256::*,
@@ -29,7 +30,14 @@ pub const TRANSIENT_STORAGE_VALIDITY_CHECK_PACKED_KEY_LENGTH: usize = 1 + 1 + 5 
 
 // FSM
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Copy, Debug)]
 #[DerivePrettyComparison("true")]
 pub struct TransientStorageDeduplicatorFSMInputOutput<F: SmallField> {
@@ -65,7 +73,14 @@ impl<F: SmallField> CSPlaceholder<F> for TransientStorageDeduplicatorFSMInputOut
     }
 }
 
-#[derive(Derivative, CSAllocatable, CSSelectable, CSVarLengthEncodable, WitnessHookable)]
+#[derive(
+    Derivative,
+    CSAllocatable,
+    CSSelectable,
+    CSVarLengthEncodable,
+    WitnessHookable,
+    WitVarLengthEncodable,
+)]
 #[derivative(Clone, Debug)]
 pub struct TransientStorageDeduplicatorInputData<F: SmallField> {
     pub unsorted_log_queue_state: QueueState<F, QUEUE_STATE_WIDTH>,


### PR DESCRIPTION
This trait makes the BWG process easier due to the fact that the witness can be encoded into a buffer without a CS.

Replaces https://github.com/matter-labs/era-zkevm_circuits/pull/40